### PR TITLE
use / slash in path in message so windows users can copy/paste

### DIFF
--- a/R/animint.R
+++ b/R/animint.R
@@ -878,7 +878,7 @@ animint2dir <- function(plot.list, out.dir = tempfile(),
     message('opening a web browser with a file:// URL; ',
             'if the web page is blank, try running
 if (!require("servr")) install.packages("servr")
-servr::httd("', out.dir, '")')
+servr::httd("', normalizePath( out.dir,winslash="/" ), '")')
       browseURL(sprintf("%s/index.html", out.dir))
   }
   invisible(meta)


### PR DESCRIPTION
This allows a Windows user to copy/paste the suggestion without having to use an escape \ or changing all slashes to /. Note, normalizePath ignores the winslash parameter on non-Windows machines so there should be no effect to nonWindows users. However,would be good to test this before pulling.
