### PR TITLE
Updated .travis.yml to port travis support to native

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -4,39 +4,19 @@
 # see the wiki:
 #   https://github.com/craigcitro/r-travis/wiki
 
-language: c
+language: r
 
-before_install:
-  - curl -OL http://raw.github.com/craigcitro/r-travis/master/scripts/travis-tool.sh
-  - chmod 755 ./travis-tool.sh
-  - ./travis-tool.sh bootstrap
-install:
-  # Basic dependencies for using animint installing/testing animint
-  - ./travis-tool.sh install_deps
-  - ./travis-tool.sh install_github tdhock/ggplot2
-  # Dependencies for shiny/rmarkdown integration
-  # Thanks RStudio! https://github.com/rstudio/rmarkdown/blob/master/.travis.yml
-  # Install binary pandoc from Rstudio 
-  - mkdir -p $HOME/opt/pandoc
-  - curl -O https://s3.amazonaws.com/rstudio-buildtools/pandoc-1.12.3.zip
-  - unzip -j pandoc-1.12.3.zip pandoc-1.12.3/linux/debian/x86_64/pandoc
-    -d $HOME/opt/pandoc
-  - chmod +x $HOME/opt/pandoc/pandoc*
-  - rm pandoc-1.12.3.zip
-  - $HOME/opt/pandoc/pandoc --version
-  # Dependencies for running animint tests
-  - ./travis-tool.sh r_binary_install servr
-  - ./travis-tool.sh r_binary_install XML
-  - ./travis-tool.sh r_binary_install shiny
-  # Binary install of rmarkdown doesn't work (currently?)
-  - ./travis-tool.sh install_github rstudio/rmarkdown
-  - ./travis-tool.sh install_github ropensci/RSelenium
-  - ./travis-tool.sh install_github ropensci/gistr
-
-script: ./travis-tool.sh run_tests
-
-after_failure:
-  - ./travis-tool.sh dump_logs
+# Dependencies for running animint tests
+r_binary_packages:
+  - servr
+  - XML
+  - shiny
+# Binary install of rmarkdown doesn't work (currently?)
+r_github_packages:
+  - tdhock/ggplot2
+  - rstudio/rmarkdown
+  - ropensci/RSelenium
+  - ropensci/gistr
 
 notifications:
   email:


### PR DESCRIPTION
Since Travis-CI now provides native support for R, this commit updates the <b>.travis.yml</b> file to port it from r-travis to native Travis support for R.