### PR TITLE
Try out wercker

### DIFF
--- a/R/testHelpers.R
+++ b/R/testHelpers.R
@@ -36,10 +36,10 @@ tests_init <- function(browserName = "phantomjs", dir = ".", port = 4848, ...) {
     selenium <- RSelenium::startServer()
   }
   # give an binaries a moment to start up
-  Sys.sleep(5)
+  Sys.sleep(8)
   remDr <<- RSelenium::remoteDriver(browserName = browserName, ...)
   # give the backend a moment to start-up
-  Sys.sleep(4)
+  Sys.sleep(6)
   remDr$open(silent = TRUE)
   Sys.sleep(2)
   # if we navigate to localhost:%s/htmltest directly, some browsers will

--- a/wercker.yml
+++ b/wercker.yml
@@ -5,11 +5,11 @@ build:
         name: echo install phantomjs
         code: |
           export PHANTOM_JS="phantomjs-1.9.8-linux-x86_64"
-	  wget https://bitbucket.org/ariya/phantomjs/downloads/$PHANTOM_JS.tar.bz2
-	  sudo tar xvjf $PHANTOM_JS.tar.bz2
+          wget https://bitbucket.org/ariya/phantomjs/downloads/$PHANTOM_JS.tar.bz2
+          sudo tar xvjf $PHANTOM_JS.tar.bz2
           sudo mv $PHANTOM_JS /usr/local/share
-	  sudo ln -sf /usr/local/share/$PHANTOM_JS/bin/phantomjs /usr/local/bin
-	  phantomjs --version
+          sudo ln -sf /usr/local/share/$PHANTOM_JS/bin/phantomjs /usr/local/bin
+          phantomjs --version
     - jimhester/r-dependencies:
       github_packages: tdhock/ggplot2 ropensci/gistr
     - jimhester/r-check

--- a/wercker.yml
+++ b/wercker.yml
@@ -3,7 +3,7 @@ build:
   steps:
     - script:
         name: echo install phantomjs
-        code: |
+        code: |-
           export PHANTOM_JS="phantomjs-1.9.8-linux-x86_64"
           wget https://bitbucket.org/ariya/phantomjs/downloads/$PHANTOM_JS.tar.bz2
           sudo tar xvjf $PHANTOM_JS.tar.bz2

--- a/wercker.yml
+++ b/wercker.yml
@@ -1,6 +1,15 @@
 box: rocker/hadleyverse
 build:
   steps:
+    - script:
+        name: echo install phantomjs
+        code: |
+          export PHANTOM_JS="phantomjs-1.9.8-linux-x86_64"
+	  wget https://bitbucket.org/ariya/phantomjs/downloads/$PHANTOM_JS.tar.bz2
+	  sudo tar xvjf $PHANTOM_JS.tar.bz2
+          sudo mv $PHANTOM_JS /usr/local/share
+	  sudo ln -sf /usr/local/share/$PHANTOM_JS/bin/phantomjs /usr/local/bin
+	  phantomjs --version
     - jimhester/r-dependencies:
       github_packages: tdhock/ggplot2 ropensci/gistr
     - jimhester/r-check

--- a/wercker.yml
+++ b/wercker.yml
@@ -1,0 +1,6 @@
+box: rocker/hadleyverse
+build:
+  steps:
+    - jimhester/r-dependencies:
+      github_packages: tdhock/ggplot2 ropensci/gistr
+    - jimhester/r-check


### PR DESCRIPTION
As discussed in #56, we've had dependency problems in the past, and comparing `sessionInfo()` output is a painful way to identify issues. This pull request is aimed at providing a better solution for the **animint** development team (@tdhock @srvanderplas @heike @kferris10 @caijun).

In an ideal world, [**animint** tests](https://github.com/tdhock/animint/wiki/Testing) will pass using the most current CRAN versions of it's dependencies, but that might not always be possible. Furthermore, **animint** tests rely on [phantomjs](http://phantomjs.org/) and [selenium](http://www.seleniumhq.org/), so this can open up a whole other can of worms…

For users sake, I propose that we use [TravisCI](https://travis-ci.org/) to report whether tests run with CRAN versions, but we should also leverage [wercker](http://wercker.com/) for development/debugging purposes. I suggest that everyone reads [this post](http://jimhester.com/post/wercker-and-rocker-finally-performant-continuous-integration-for-r) to understand the benefits that wercker can provide over Travis. 

Most importantly, wercker allows us to [pull](http://devcenter.wercker.com/docs/build/pulling-builds.html) down and [inspect](http://devcenter.wercker.com/docs/build/introspecting-builds.html) the _same_ testing environment locally (assuming you can [install docker/wercker](http://devcenter.wercker.com/docs/cli/requirements.html)). This makes it much easier to depend on specific versions of packages if we need to...

I'm sure people will have questions/issues at some point, so feel free to ask away!