### PR TITLE
bugfix for transparent fill, many layers

### DIFF
--- a/NEWS
+++ b/NEWS
@@ -188,6 +188,15 @@ does not respond to mouse clicks while the data is loading.
 DSL: Implement shape aesthetic with d3.svg.symbol()
 https://github.com/mbostock/d3/wiki/SVG-Shapes#symbol_type
 
+2015.05.21
+
+BUGFIX: linetypes, legend ordering, color=NA means "transparent" etc
+https://github.com/tdhock/animint/pull/72
+
+BUGFIX: Testing should now work on Windows with Firefox.
+
+For complete details, see https://github.com/tdhock/animint/pull/70
+
 2015.05.20 https://github.com/tdhock/animint/pull/48
 
 RENDER: if the animation is paused when the user hides the animint
@@ -201,12 +210,6 @@ BUGFIX: facet_grid bugfix for when there is only 1 row or column.
 BUGFIX: R colors defined in parameters such as
 geom_line(colour="grey50") are now corrected translated to 
 rgb(127, 127, 127) in JSON.
-
-2015.05.21
-
-BUGFIX: Testing should now work on Windows with Firefox.
-
-For complete details, see https://github.com/tdhock/animint/pull/70
 
 2015.05.11
 

--- a/R/animint.R
+++ b/R/animint.R
@@ -568,12 +568,14 @@ saveLayer <- function(l, d, meta){
           chunk.vec <- g.data[[chunk.var]]
           counts <- table(chunk.vec)
           if(length(counts) == 1){
-            stop("only 1 chunk") # do we ever get here?
-          }
-          if(all(counts == 1)){
-            FALSE #each chunk has only 1 row -- chunks are too small.
-          }else{
+            ##stop("only 1 chunk") # do we ever get here?
             TRUE
+          }else{
+            if(all(counts == 1)){
+              FALSE #each chunk has only 1 row -- chunks are too small.
+            }else{
+              TRUE
+            }
           }
         }else{
           FALSE

--- a/R/animint.R
+++ b/R/animint.R
@@ -1112,7 +1112,7 @@ getLegend <- function(mb){
   if(length(dataframes)>0) {
     data <- merge_recurse(dataframes)
   } else return(NULL)
-  data <- lapply(nrow(data):1, function(i) as.list(data[i,]))
+  data <- lapply(1:nrow(data), function(i) as.list(data[i,]))
   if(guidetype=="none"){
     NULL
   } else{

--- a/R/animint.R
+++ b/R/animint.R
@@ -858,7 +858,8 @@ animint2dir <- function(plot.list, out.dir = tempfile(),
         update.vars <- L$mapping[is.ss | is.cs]
         has.var <- update.vars %in% names(L$data)
         if(!all(has.var)){
-          print(list(interactive.variables=update.vars[!has.var],
+          print(L)
+          print(list(problem.aes=update.vars[!has.var],
                      data.variables=names(L$data)))
           stop("data does not have interactive variables")
         }

--- a/R/animint.R
+++ b/R/animint.R
@@ -563,22 +563,18 @@ saveLayer <- function(l, d, meta){
         chunk.cols <- NULL
       }else{
         can.chunk.i <- which(can.chunk)[[1]]
-        several.chunks <- if(length(g$subset_order)){
+        several.chunks <- if(length(g$subset_order)==0) FALSE else {
           chunk.var <- subset.vec[[can.chunk.i]]
           chunk.vec <- g.data[[chunk.var]]
           counts <- table(chunk.vec)
           if(length(counts) == 1){
             ##stop("only 1 chunk") # do we ever get here?
             TRUE
+          }else if(all(counts == 1)){
+            FALSE #each chunk has only 1 row -- chunks are too small.
           }else{
-            if(all(counts == 1)){
-              FALSE #each chunk has only 1 row -- chunks are too small.
-            }else{
-              TRUE
-            }
+            TRUE
           }
-        }else{
-          FALSE
         }
         if(several.chunks){
           nest.cols <- subset.vec[-can.chunk.i]

--- a/R/animint.R
+++ b/R/animint.R
@@ -858,7 +858,8 @@ animint2dir <- function(plot.list, out.dir = tempfile(),
         update.vars <- L$mapping[is.ss | is.cs]
         has.var <- update.vars %in% names(L$data)
         if(!all(has.var)){
-          print(update.vars[!has.var])
+          print(list(interactive.variables=update.vars[!has.var],
+                     data.variables=names(L$data)))
           stop("data does not have interactive variables")
         }
         has.cs <- any(is.cs)

--- a/R/animint.R
+++ b/R/animint.R
@@ -1005,10 +1005,13 @@ is.rgb <- function(x){
 
 #' Convert R colors to RGB hexadecimal color values
 #' @param x character
-#' @return hexadecimal color value (if is.na(x), return "none" for compatibility with JavaScript)
+#' @return hexadecimal color value or "transparent" if is.na
 #' @export
 toRGB <- function(x){
-  named.vec <- sapply(x, function(i) if(!is.na(i)) rgb(t(col2rgb(as.character(i))), maxColorValue=255) else "none")
+  is.transparent <- is.na(x) | x=="transparent"
+  rgb.mat <- col2rgb(x)
+  rgb.vec <- rgb(t(rgb.mat), maxColorValue=255)
+  named.vec <- ifelse(is.transparent, "transparent", rgb.vec)
   not.named <- as.character(named.vec)
   not.named
 }

--- a/inst/htmljs/animint.js
+++ b/inst/htmljs/animint.js
@@ -9,11 +9,11 @@ var animint = function (to_select, json_file) {
   var linetypesize2dasharray = function (lt, size) {
     var isInt = function(n) { return typeof n === 'number' && parseFloat(n) == parseInt(n, 10) && !isNaN(n); }
     if(isInt(lt)){ // R integer line types.
-      if(lt == 0){
+      if(lt == 1){
 	return null;
       }
       var o = {
-	1: 0,
+	0: size * 0 + "," + size * 10,
 	2: size * 4 + "," + size * 4,
 	3: size + "," + size * 2,
 	4: size + "," + size * 2 + "," + size * 4 + "," + size * 2,
@@ -1455,7 +1455,7 @@ var animint = function (to_select, json_file) {
 	  .attr("height", 10)
           .style("stroke-width", function(d){return d["polygonsize"]||1;})
           .style("stroke-dasharray", function(d){
-	    return linetypesize2dasharray(d["polygonlinetype"]||"solid",
+	    return linetypesize2dasharray(d["polygonlinetype"],
 					  d["size"]||2);
 	  })
           .style("stroke", function(d){return d["polygoncolour"] || "#000000";})
@@ -1481,7 +1481,7 @@ var animint = function (to_select, json_file) {
 	    return linescale(d["pathsize"])||2;
 	  })
           .style("stroke-dasharray", function(d){
-	    return linetypesize2dasharray(d["pathlinetype"]||"solid",
+	    return linetypesize2dasharray(d["pathlinetype"],
 					  d["pathsize"] || 2);
 	  })
           .style("stroke", function(d){return d["pathcolour"] || "#000000";})

--- a/tests/testthat/test-linetype.R
+++ b/tests/testthat/test-linetype.R
@@ -16,18 +16,25 @@ dasharrayPattern <-
 
 rect.xpaths <- 
   c('//svg[@id="numeric"]//rect',
-    '//svg[@id="character"]//rect')
+    '//svg[@id="character"]//rect',
+    '//td[@id="numeric_legend"]//rect',
+    '//td[@id="character_legend"]//rect')
+    
 
 test_that("linetypes render correctly", {
   viz <-
     list(numeric=gg+
            scale_linetype_manual(values=c(correct=0,
                                    "false positive"=1,
-                                   "false negative"=3)),
+                                   "false negative"=3),
+                                limits=c("correct", "false positive",
+                                 "false negative")),
 
          character=gg+scale_linetype_manual(values=c(correct="blank",
                                               "false positive"="solid",
-                                              "false negative"="dotted")))
+                                              "false negative"="dotted"),
+                                limits=c("correct", "false positive",
+                                 "false negative")))
   info <- animint2HTML(viz)
 
   for(xpath in rect.xpaths){

--- a/tests/testthat/test-linetype.R
+++ b/tests/testthat/test-linetype.R
@@ -1,0 +1,43 @@
+context("linetype")
+
+df <- data.frame(x=1:3, status=c("correct", "false positive", "false negative"))
+
+gg <- 
+  ggplot(df)+
+    geom_point(aes(x, x))+
+    geom_tallrect(aes(xmin=x, xmax=x+0.5, linetype=status),
+                  fill="grey",
+                  color="black")
+
+dasharrayPattern <-
+  paste0("stroke-dasharray:",
+         "(?<value>.*?)",
+         ";")
+
+rect.xpaths <- 
+  c('//svg[@id="numeric"]//rect',
+    '//svg[@id="character"]//rect')
+
+test_that("linetypes render correctly", {
+  viz <-
+    list(numeric=gg+
+           scale_linetype_manual(values=c(correct=0,
+                                   "false positive"=1,
+                                   "false negative"=3)),
+
+         character=gg+scale_linetype_manual(values=c(correct="blank",
+                                              "false positive"="solid",
+                                              "false negative"="dotted")))
+  info <- animint2HTML(viz)
+
+  for(xpath in rect.xpaths){
+    node.set <- getNodeSet(info$html, xpath)
+    expect_equal(length(node.set), 3)
+    attr.mat <- sapply(node.set, xmlAttrs)
+    match.mat <- str_match_perl(attr.mat["style",], dasharrayPattern)
+    value.vec <- match.mat[, "value"]
+    expect_match(value.vec[1], "0(px)?, *20(px)?")
+    expect_identical(value.vec[2], NA_character_)
+    expect_match(value.vec[3], "2(px)?, *4(px)?")
+  }
+})

--- a/tests/testthat/test-params.R
+++ b/tests/testthat/test-params.R
@@ -15,6 +15,18 @@ pattern <-
          "(?<value>.+?)",
          ";")
 
+test_that("transparent does not convert", {
+  expect_identical(animint::toRGB("transparent"), "transparent")
+})
+
+test_that("NA converts to transparent", {
+  expect_identical(animint::toRGB(NA), "transparent")
+})
+
+test_that("grey50 converts", {
+  expect_identical(animint::toRGB("grey50"), "#7F7F7F")
+})
+
 test_that("color is converted to RGB colour", {
   info <- animint2HTML(viz)
 

--- a/tests/testthat/test-params.R
+++ b/tests/testthat/test-params.R
@@ -16,15 +16,15 @@ pattern <-
          ";")
 
 test_that("transparent does not convert", {
-  expect_identical(animint::toRGB("transparent"), "transparent")
+  expect_identical(toRGB("transparent"), "transparent")
 })
 
 test_that("NA converts to transparent", {
-  expect_identical(animint::toRGB(NA), "transparent")
+  expect_identical(toRGB(NA), "transparent")
 })
 
 test_that("grey50 converts", {
-  expect_identical(animint::toRGB("grey50"), "#7F7F7F")
+  expect_identical(toRGB("grey50"), "#7F7F7F")
 })
 
 test_that("color is converted to RGB colour", {
@@ -32,7 +32,7 @@ test_that("color is converted to RGB colour", {
 
   expect_equal(length(info$geoms), 1)
   g <- info$geoms[[1]]
-  expected.colour <- as.character(animint::toRGB("grey50"))
+  expected.colour <- as.character(toRGB("grey50"))
   expect_identical(g$params$colour, expected.colour)
   
   node.list <- getNodeSet(info$html, '//g[@class="geom1_step_step"]//path')


### PR DESCRIPTION
#48 fixed the bug that converts color parameters such as `geom_line(color="grey50")` to the proper RGB values, but this also introduced a bug which converts "transparent" to white.

This PR fixes that bug. It also adds tests, including one that makes sure that `toRGB(NA)=="transparent"` as in ggplot2.