### PR TITLE
Panel backgrounds

### DIFF
--- a/R/animint.R
+++ b/R/animint.R
@@ -77,9 +77,9 @@ parsePlot <- function(meta){
       temp_background$linetype <- "solid"
     } else {
       # make sure linetype is correctly specified
-      stopifnot(temp_background$linetype %in% 
-                  c("blank", "solid", "dashed", "dotted", 
-                    "dotdash", "longdash", "twodash"))
+      stopifnot(
+        temp_background$linetype %in% c("blank", "solid", "dashed", "dotted", "dotdash", "longdash", "twodash") | 
+          is.numeric(temp_background$linetype))
     }
   }
   # saving background info

--- a/R/animint.R
+++ b/R/animint.R
@@ -59,6 +59,31 @@ parsePlot <- function(meta){
   ## grid 0-1 scale). This allows transformations to be used
   ## out of the box, with no additional d3 coding.
   theme.pars <- ggplot2:::plot_theme(meta$plot)
+  
+  ## extract pnale backgrounds from theme.pars
+  temp_background <- theme.pars$panel.background
+  # convert fill to RGB if necessary
+  if(!(is.rgb(temp_background$fill))) { 
+    temp_background$fill <- toRGB(temp_background$fill)
+  }
+  # if border color is specified
+  if(!is.na(temp_background$colour)) {
+    # convert color to RGB if necessary
+    if(!(is.rgb(temp_background$colour))) { 
+      temp_background$colour <- toRGB(temp_background$colour)
+    }
+    # check if the user specified linetype for the border
+    if(is.null(temp_background$linetype)) {
+      temp_background$linetype <- "solid"
+    } else {
+      # make sure linetype is correctly specified
+      stopifnot(temp_background$linetype %in% 
+                  c("blank", "solid", "dashed", "dotted", 
+                    "dotdash", "longdash", "twodash"))
+    }
+  }
+  # saving background info
+  plot.meta$panel_background <- temp_background
 
   ## Flip labels if coords are flipped - transform does not take care
   ## of this. Do this BEFORE checking if it is blank or not, so that

--- a/inst/htmljs/animint.js
+++ b/inst/htmljs/animint.js
@@ -8,53 +8,57 @@ var animint = function (to_select, json_file) {
 
   var linetypesize2dasharray = function (lt, size) {
     var isInt = function(n) { return typeof n === 'number' && parseFloat(n) == parseInt(n, 10) && !isNaN(n); }
-    if(isInt(lt)){ // R integer line types.
-      if(lt == 1){
-	return null;
+    if(lt == null) {
+      return null;
+    } else {
+      if(isInt(lt)){ // R integer line types.
+        if(lt == 1){
+  	return null;
+        }
+        var o = {
+  	0: size * 0 + "," + size * 10,
+  	2: size * 4 + "," + size * 4,
+  	3: size + "," + size * 2,
+  	4: size + "," + size * 2 + "," + size * 4 + "," + size * 2,
+  	5: size * 8 + "," + size * 4,
+  	6: size * 2 + "," + size * 2 + "," + size * 6 + "," + size * 2
+        };
+      } else { //R defined line types
+        if(lt == "solid"){
+  	return null;
+        }
+        var o = {
+  	"blank": size * 0 + "," + size * 10,
+  	"none": size * 0 + "," + size * 10,
+  	"dashed": size * 4 + "," + size * 4,
+  	"dotted": size + "," + size * 2,
+  	"dotdash": size + "," + size * 2 + "," + size * 4 + "," + size * 2,
+  	"longdash": size * 8 + "," + size * 4,
+  	"twodash": size * 2 + "," + size * 2 + "," + size * 6 + "," + size * 2,
+  	"22": size * 2 + "," + size * 2,
+  	"42": size * 4 + "," + size * 2,
+  	"44": size * 4 + "," + size * 4,
+  	"13": size + "," + size * 3,
+  	"1343": size + "," + size * 3 + "," + size * 4 + "," + size * 3,
+  	"73": size * 7 + "," + size * 3,
+  	"2262": size * 2 + "," + size * 2 + "," + size * 6 + "," + size * 2,
+  	"12223242": size + "," + size * 2 + "," + size * 2 + "," + size * 2 + "," + size * 3 + "," + size * 2 + "," + size * 4 + "," + size * 2,
+  	"F282": size * 15 + "," + size * 2 + "," + size * 8 + "," + size * 2,
+  	"F4448444": size * 15 + "," + size * 4 + "," + size * 4 + "," + size * 4 + "," + size * 8 + "," + size * 4 + "," + size * 4 + "," + size * 4,
+  	"224282F2": size * 2 + "," + size * 2 + "," + size * 4 + "," + size * 2 + "," + size * 8 + "," + size * 2 + "," + size * 16 + "," + size * 2,
+  	"F1": size * 16 + "," + size
+        };
       }
-      var o = {
-	0: size * 0 + "," + size * 10,
-	2: size * 4 + "," + size * 4,
-	3: size + "," + size * 2,
-	4: size + "," + size * 2 + "," + size * 4 + "," + size * 2,
-	5: size * 8 + "," + size * 4,
-	6: size * 2 + "," + size * 2 + "," + size * 6 + "," + size * 2
-      };
-    } else { //R defined line types
-      if(lt == "solid"){
-	return null;
-      }
-      var o = {
-	"blank": size * 0 + "," + size * 10,
-	"none": size * 0 + "," + size * 10,
-	"dashed": size * 4 + "," + size * 4,
-	"dotted": size + "," + size * 2,
-	"dotdash": size + "," + size * 2 + "," + size * 4 + "," + size * 2,
-	"longdash": size * 8 + "," + size * 4,
-	"twodash": size * 2 + "," + size * 2 + "," + size * 6 + "," + size * 2,
-	"22": size * 2 + "," + size * 2,
-	"42": size * 4 + "," + size * 2,
-	"44": size * 4 + "," + size * 4,
-	"13": size + "," + size * 3,
-	"1343": size + "," + size * 3 + "," + size * 4 + "," + size * 3,
-	"73": size * 7 + "," + size * 3,
-	"2262": size * 2 + "," + size * 2 + "," + size * 6 + "," + size * 2,
-	"12223242": size + "," + size * 2 + "," + size * 2 + "," + size * 2 + "," + size * 3 + "," + size * 2 + "," + size * 4 + "," + size * 2,
-	"F282": size * 15 + "," + size * 2 + "," + size * 8 + "," + size * 2,
-	"F4448444": size * 15 + "," + size * 4 + "," + size * 4 + "," + size * 4 + "," + size * 8 + "," + size * 4 + "," + size * 4 + "," + size * 4,
-	"224282F2": size * 2 + "," + size * 2 + "," + size * 4 + "," + size * 2 + "," + size * 8 + "," + size * 2 + "," + size * 16 + "," + size * 2,
-	"F1": size * 16 + "," + size
-      };
-    }
 
-    if (lt in o){
-      return o[lt];
-    } else{ // manually specified line types
-      str = lt.split("");
-      strnum = str.map(function (d) {
-	return size * parseInt(d, 16);
-      });
-      return strnum;
+      if (lt in o){
+        return o[lt];
+      } else{ // manually specified line types
+        str = lt.split("");
+        strnum = str.map(function (d) {
+  	return size * parseInt(d, 16);
+        });
+        return strnum;
+      }
     }
   }
 

--- a/inst/htmljs/animint.js
+++ b/inst/htmljs/animint.js
@@ -517,9 +517,9 @@ var animint = function (to_select, json_file) {
         .attr("y", plotdim.ystart)
         .attr("width", plotdim.xend - plotdim.xstart)
         .attr("height", plotdim.yend - plotdim.ystart)
-        .attr("fill", p_info.panel_background.fill)
-        .attr("stroke", p_info.panel_background.colour)
-        .attr("stroke-dasharray", function() {
+        .style("fill", p_info.panel_background.fill)
+        .style("stroke", p_info.panel_background.colour)
+        .style("stroke-dasharray", function() {
           return linetypesize2dasharray(p_info.panel_background.linetype,
                                         p_info.panel_background.size);
         });

--- a/inst/htmljs/animint.js
+++ b/inst/htmljs/animint.js
@@ -510,6 +510,14 @@ var animint = function (to_select, json_file) {
 
     Plots[p_name].scales = scales;
 
+    // draw background
+    svg.append("rect")
+      .attr("x", plotdim.xstart)
+      .attr("y", plotdim.ystart)
+      .attr("width", graph_width)
+      .attr("height", graph_height)
+      .attr("fill", p_info.panel_background.fill);
+
   } //end of add_plot()
 
   var add_selector = function (s_name, s_info) {

--- a/inst/htmljs/animint.js
+++ b/inst/htmljs/animint.js
@@ -511,11 +511,12 @@ var animint = function (to_select, json_file) {
     Plots[p_name].scales = scales;
 
     // draw background
-    svg.append("rect")
+    // uses insert to draw it right before the #plottitle
+    svg.insert("rect", "#plottitle")
       .attr("x", plotdim.xstart)
       .attr("y", plotdim.ystart)
-      .attr("width", graph_width)
-      .attr("height", graph_height)
+      .attr("width", plotdim.xend - plotdim.xstart)
+      .attr("height", plotdim.yend - plotdim.ystart)
       .attr("fill", p_info.panel_background.fill);
 
   } //end of add_plot()

--- a/inst/htmljs/animint.js
+++ b/inst/htmljs/animint.js
@@ -505,19 +505,19 @@ var animint = function (to_select, json_file) {
     	if(!axis.yticks) {
     	  styles.push("#"+p_name+" #yaxis .tick"+" line{stroke:none;}");
     	}
+      
+      // draw background
+      // uses insert to draw it right before the #plottitle
+      svg.insert("rect", "#plottitle")
+        .attr("x", plotdim.xstart)
+        .attr("y", plotdim.ystart)
+        .attr("width", plotdim.xend - plotdim.xstart)
+        .attr("height", plotdim.yend - plotdim.ystart)
+        .attr("fill", p_info.panel_background.fill);
 
     } //end of for loop
 
     Plots[p_name].scales = scales;
-
-    // draw background
-    // uses insert to draw it right before the #plottitle
-    svg.insert("rect", "#plottitle")
-      .attr("x", plotdim.xstart)
-      .attr("y", plotdim.ystart)
-      .attr("width", plotdim.xend - plotdim.xstart)
-      .attr("height", plotdim.yend - plotdim.ystart)
-      .attr("fill", p_info.panel_background.fill);
 
   } //end of add_plot()
 

--- a/inst/htmljs/animint.js
+++ b/inst/htmljs/animint.js
@@ -513,7 +513,9 @@ var animint = function (to_select, json_file) {
         .attr("y", plotdim.ystart)
         .attr("width", plotdim.xend - plotdim.xstart)
         .attr("height", plotdim.yend - plotdim.ystart)
-        .attr("fill", p_info.panel_background.fill);
+        .attr("fill", p_info.panel_background.fill)
+        .attr("stroke", p_info.panel_background.colour)
+        .attr("stroke-width", p_info.panel_background.size);
 
     } //end of for loop
 

--- a/inst/htmljs/animint.js
+++ b/inst/htmljs/animint.js
@@ -515,7 +515,10 @@ var animint = function (to_select, json_file) {
         .attr("height", plotdim.yend - plotdim.ystart)
         .attr("fill", p_info.panel_background.fill)
         .attr("stroke", p_info.panel_background.colour)
-        .attr("stroke-width", p_info.panel_background.size);
+        .attr("stroke-dasharray", function() {
+          return linetypesize2dasharray(p_info.panel_background.linetype,
+                                        p_info.panel_background.size);
+        });
 
     } //end of for loop
 


### PR DESCRIPTION
This is a start at coloring background panels.  

In `animint.R`, I [added some code](https://github.com/kferris10/animint/blob/panel_backgrounds/R/animint.R#L64) to extract the `ggplot2:::plot_theme(plot)$panel.background` for each of the panels.

In `animint.js`, to draw the backgrounds I would like to do something [like this](https://github.com/kferris10/animint/blob/panel_backgrounds/inst/htmljs/animint.js#L513)

    svg.append("rect")
          .attr("x", plotdim.xstart)
          .attr("y", plotdim.ystart)
          .attr("width", graph_width)
          .attr("height", graph_height)
         .attr("fill", p_info.panel_background.fill);

However, the result is something like this (I'm trying to give a light blue background to the sepal plot and a light grey background to the petal plot).  There's a problem because it is drawing the rectangles after drawing the points.  

![image](https://cloud.githubusercontent.com/assets/6612411/7791842/c9f44450-0264-11e5-9af8-82bd32de2e7a.png)

If I put that line of code before [this part](https://github.com/kferris10/animint/blob/panel_backgrounds/inst/htmljs/animint.js#L288) then the backgrounds will be drawn before the points.  So I could calculate the locations and sizes of the background rectangles and draw them before this part of the code, but that seems somewhat redundant.  These plot sizes are all calculated in [the for loop](https://github.com/kferris10/animint/blob/panel_backgrounds/inst/htmljs/animint.js#L312) in `add_plot()`.  

Hope all this makes sense.  I'm a bit confused here so I thought I'd check with you guys before continuing on my own.  Thanks!