### PR TITLE
Fix ":262 in error" when running tests_init()

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,6 +1,6 @@
-language: 
+language: c
 
-sudo: requiredc
+sudo: required
 
 before_install:
   - curl -OL http://raw.github.com/craigcitro/r-travis/master/scripts/travis-tool.sh

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,4 +1,6 @@
-language: c
+language: 
+
+sudo: requiredc
 
 before_install:
   - curl -OL http://raw.github.com/craigcitro/r-travis/master/scripts/travis-tool.sh

--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -29,4 +29,3 @@ Suggests:
     XML,
     devtools,
     maps
-Roxygen: list(wrap = TRUE)

--- a/R/geoms.R
+++ b/R/geoms.R
@@ -122,7 +122,7 @@ make_bar <- function(data, x.name, alpha=1){
 #' @param x x coordinate of label position
 #' @param y y coordinate of label position
 #' @param label.var variable matching showSelected, used to obtain label value
-#' @param format String format for label. Use %d, %f, etc. to insert relevant label.var value.
+#' @param format String format for label. Use \%d, \%f, etc. to insert relevant label.var value.
 #' @return a geom_text layer.
 #' @author Toby Dylan Hocking
 #' @export

--- a/R/testHelpers.R
+++ b/R/testHelpers.R
@@ -99,7 +99,6 @@ tests_run <- function(dir = ".", filter = NULL) {
 #' @seealso \link{tests_run}
 #' @export
 tests_exit <- function() {
-  
   res <- stop_binary()
   Sys.unsetenv("ANIMINT_BROWSER")
   # release port used for local file server

--- a/R/testHelpers.R
+++ b/R/testHelpers.R
@@ -99,14 +99,14 @@ tests_run <- function(dir = ".", filter = NULL) {
 #' @seealso \link{tests_run}
 #' @export
 tests_exit <- function() {
+  
   res <- stop_binary()
   Sys.unsetenv("ANIMINT_BROWSER")
-  e <- try(readLines(pid_file(), warn = FALSE), silent = TRUE)
-  if (!inherits(e, "try-error")) {
-    pids <- as.integer(e)
-    res <- c(res, tools::pskill(pids))
+  # release port used for local file server
+  if (exists("serv.port")) {
+    pid <- port2pid(port = serv.port)
+    res <- c(res, tools::pskill(pid))
   }
-  unlink(pid_file())
   invisible(all(res))
 }
 
@@ -118,13 +118,11 @@ tests_exit <- function() {
 #' @param port port number to _attempt_ to run server on.
 #' @param code R code to execute in a child session
 #' @return port number of the successful attempt
-run_servr <- function(directory = ".", port = 4848,
+run_servr <- function(directory = ".", port = 4848, 
                       code = "servr::httd(dir='%s', port=%d)") {
+  assign("serv.port", port, envir = .GlobalEnv)
   dir <- normalizePath(directory, winslash = "/", mustWork = TRUE)
-  cmd <- sprintf(
-    paste("library(methods); write.table(Sys.getpid(), file='%s', append=T, row.name=F, col.names=F);", code),
-    pid_file(), dir, port
-  )
+  cmd <- sprintf(code, dir, port)
   system2("Rscript", c("-e", shQuote(cmd)), wait = FALSE)
 }
 
@@ -140,14 +138,13 @@ stop_binary <- function() {
     remDr$closeWindow()
     remDr$closeServer()
   }, silent = TRUE)
+  # remDr doesn't release the default port 4444
+  # remDr or pJS are removed accidently, but the default port is still occupied.
+  # Failed to create server for GhostDriver
+  # kill process explicitly
+  pid <- port2pid()
+  tools::pskill(pid)
   TRUE
-}
-
-# file that will keep track of all processes were initiated during animint testing
-pid_file <- function() {
-  f <- file.path(find_test_path(), "pids.txt")
-  if (!file.exists(f)) file(f)
-  f
 }
 
 # find the path to animint's testthat directory
@@ -163,4 +160,13 @@ find_test_path <- function(dir = ".") {
                     tests = "testthat",
                     testthat = "")
   file.path(dir, ext_dir)
+}
+
+# get process id via port number
+port2pid <- function(port = 4444) {
+#   args <- paste0("-i :", port, " -t")
+#   pid <- as.integer(system2("lsof", args = args, stdout = TRUE))
+  cmd <- paste0("lsof -i :", port, " -t")
+  pid <- as.integer(system(cmd, intern = TRUE))
+  pid
 }

--- a/tests/testthat/helper-functions.R
+++ b/tests/testthat/helper-functions.R
@@ -83,6 +83,14 @@ expect_styles <- function(html, styles.expected){
   }
 }
 
+getStyleValue <- function(html, xpath, style.name) {
+  nodes <- getNodeSet(html, xpath)
+  node.style <- xmlAttrs(nodes[[1]])["style"]
+  pattern <-paste0("(?<name>\\S+?)", ": *", "(?<value>.+?)", ";")
+  style.matrices <- str_match_all_perl(node.style, pattern)
+  style.value <- style.matrices[[1]][style.name, "value"]
+}
+
 ## Parse the first occurance of pattern from each of several strings
 ## using (named) capturing regular expressions, returning a matrix
 ## (with column names).

--- a/tests/testthat/test-hjust-text-anchor.R
+++ b/tests/testthat/test-hjust-text-anchor.R
@@ -77,14 +77,6 @@ grad.desc.viz <- function(hjust) {
               title = "Demonstration of Gradient Descent Algorithm")
 }
 
-getStyleValue <- function(html, xpath, style.name) {
-  nodes <- getNodeSet(html, xpath)
-  node.style <- xmlAttrs(nodes[[1]])["style"]
-  pattern <-paste0("(?<name>\\S+?)", ": *", "(?<value>.+?)", ";")
-  style.matrices <- str_match_all_perl(node.style, pattern)
-  style.value <- style.matrices[[1]][style.name, "value"]
-}
-
 test_that('geom_text(hjust=0) => <text style="text-anchor: start">', {
   viz <- grad.desc.viz(hjust = 0)
   info <- animint2HTML(viz)


### PR DESCRIPTION
As reported in tdhock/animint#66, this branch fixes the `:262 in error` when running `tests_init()` after `tests_init("firefox)`. My idea is to get process ids by port number used in animint. `tests_init()` should run in the environment that no processes occupy the port number. Also, this makes the code more succinct comparing by using `pid.txt`.

The branch works well in creating and exiting remote server of selenium on my Mac OS X 10.10.3, even though the following error and warning occur.

```
Error in startServer(host, port, app) : Failed to create server
Calls: <Anonymous> -> <Anonymous> -> startServer
Execution halted
```
This error is likely to result from `httpuv::startServer()`, which I haven't trace back.
```
Warning message:
running command 'lsof -i :4444 -t' had status 1 
```
This warning has no influence to our functions. Hence, I will suppress it in the future.

@tdhock and @cpsievert can review the changes and give comments.