### PR TITLE
legend entry order

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,7 +1,7 @@
 Package: animint
 Maintainer: Toby Dylan Hocking <tdhock5@gmail.com>
 Author: Toby Dylan Hocking, Susan VanderPlas, Carson Sievert
-Version: 2015.05.21
+Version: 2015.05.28
 License: GPL-3
 Title: Interactive animations
 Description: An interactive animation can be defined using a list of

--- a/NEWS
+++ b/NEWS
@@ -199,6 +199,12 @@ does not respond to mouse clicks while the data is loading.
 DSL: Implement shape aesthetic with d3.svg.symbol()
 https://github.com/mbostock/d3/wiki/SVG-Shapes#symbol_type
 
+2015.05.28
+
+BUGFIX: ordering of legend entries now correctly reverses the order of
+numeric legend entries, so that smaller numbers appear lower in the
+legend.
+
 2015.05.21
 
 BUGFIX: linetypes, legend ordering, color=NA means "transparent" etc

--- a/R/animint.R
+++ b/R/animint.R
@@ -1085,7 +1085,6 @@ getLegendList <- function(plistextra){
 #' Function to get legend information for each scale
 #' @param mb single entry from ggplot2:::guides_merge() list of legend data
 #' @return list of legend information, NULL if guide=FALSE.
-
 getLegend <- function(mb){
   guidetype <- mb$name
   ## The main idea of legends:

--- a/inst/htmljs/animint.js
+++ b/inst/htmljs/animint.js
@@ -1501,6 +1501,7 @@ var animint = function (to_select, json_file) {
       }
       legend_rows.append("td")
 	.attr("align", "left")
+	.attr("id", "legend_entry_label")
 	.text(function(d){ return d["label"];})
       ;
     }

--- a/inst/htmljs/animint.js
+++ b/inst/htmljs/animint.js
@@ -1501,7 +1501,7 @@ var animint = function (to_select, json_file) {
       }
       legend_rows.append("td")
 	.attr("align", "left")
-	.attr("id", "legend_entry_label")
+	.attr("class", "legend_entry_label")
 	.text(function(d){ return d["label"];})
       ;
     }

--- a/tests/testthat/test-legends.R
+++ b/tests/testthat/test-legends.R
@@ -75,7 +75,7 @@ gg <-
 
 expected.legend.list <- 
   list(increasing=1:3,
-       default=seq(3, 1, by=0.5),
+       default=seq(3, 1, by=-0.5),
        decreasing=3:1)
     
 test_that("renderer shows legend entries in correct order", {

--- a/tests/testthat/test-legends.R
+++ b/tests/testthat/test-legends.R
@@ -86,6 +86,8 @@ test_that("renderer shows legend entries in correct order", {
            scale_fill_continuous(breaks=3:1),
          default=gg)
   info <- animint2HTML(viz)
+  ##sapply(info$plots, function(p)sapply(p$legend$x$entries, "[[", "label"))
+  
   ## NOTE: it is important to test the renderer here (not the
   ## compiler) since maybe the order specified in the plot.json file
   ## is not the same as the order of appearance on the web page.

--- a/tests/testthat/test-legends.R
+++ b/tests/testthat/test-legends.R
@@ -64,8 +64,11 @@ test_that('hiding all legends works with theme(legend.position="none")',{
   expect_identical(generated.names, NULL)
 })
 
+error.types <-
+  data.frame(x=1:3, status=c("correct", "false positive", "false negative"))
+
 gg <- 
-  ggplot(df)+
+  ggplot(error.types)+
     geom_point(aes(x, x))+
     geom_tallrect(aes(xmin=x, xmax=x+0.5, fill=x),
                   color="black")

--- a/tests/testthat/test-legends.R
+++ b/tests/testthat/test-legends.R
@@ -75,7 +75,7 @@ gg <-
 
 expected.legend.list <- 
   list(increasing=1:3,
-       default=seq(1, 3, by=0.5),
+       default=seq(3, 1, by=0.5),
        decreasing=3:1)
     
 test_that("renderer shows legend entries in correct order", {

--- a/tests/testthat/test-legends.R
+++ b/tests/testthat/test-legends.R
@@ -64,3 +64,44 @@ test_that('hiding all legends works with theme(legend.position="none")',{
   expect_identical(generated.names, NULL)
 })
 
+gg <- 
+  ggplot(df)+
+    geom_point(aes(x, x))+
+    geom_tallrect(aes(xmin=x, xmax=x+0.5, fill=x),
+                  color="black")
+
+expected.legend.list <- 
+  list(increasing=1:3,
+       default=seq(1, 3, by=0.5),
+       decreasing=3:1)
+    
+test_that("renderer shows legend entries in correct order", {
+  viz <-
+    list(increasing=gg+
+           scale_fill_continuous(breaks=1:3),
+         decreasing=gg+
+           scale_fill_continuous(breaks=3:1),
+         default=gg)
+  info <- animint2HTML(viz)
+  ## NOTE: it is important to test the renderer here (not the
+  ## compiler) since maybe the order specified in the plot.json file
+  ## is not the same as the order of appearance on the web page.
+
+  ## The expected behavior is smaller numeric entries on the bottom of
+  ## the legend by default, and if they are manually specified via
+  ## breaks, we have:
+  breaks <-
+    c("top",
+      "middle",
+      "bottom")
+  for(plot.name in names(expected.legend.list)){
+    xpath <-
+      sprintf('//td[@id="%s_legend"]//td[@class="legend_entry_label"]',
+              plot.name)
+    expected.entries <- expected.legend.list[[plot.name]]
+    node.set <- getNodeSet(info$html, xpath)
+    value.str <- sapply(node.set, xmlValue)
+    value.num <- as.numeric(value.str)
+    expect_equal(value.num, expected.entries)
+  }
+})

--- a/tests/testthat/test-linetype.R
+++ b/tests/testthat/test-linetype.R
@@ -19,7 +19,6 @@ rect.xpaths <-
     '//svg[@id="character"]//rect',
     '//td[@id="numeric_legend"]//rect',
     '//td[@id="character_legend"]//rect')
-    
 
 test_that("linetypes render correctly", {
   viz <-

--- a/tests/testthat/test-linetype.R
+++ b/tests/testthat/test-linetype.R
@@ -1,9 +1,10 @@
 context("linetype")
 
-df <- data.frame(x=1:3, status=c("correct", "false positive", "false negative"))
+error.types <-
+  data.frame(x=1:3, status=c("correct", "false positive", "false negative"))
 
 gg <- 
-  ggplot(df)+
+  ggplot(error.types)+
     geom_point(aes(x, x))+
     geom_tallrect(aes(xmin=x, xmax=x+0.5, linetype=status),
                   fill="grey",


### PR DESCRIPTION
This branch contains a test that fails for the order of legend entries.

First of all we need to attach the "legend_entry_label" class to the legend entry label `<td>` elements.

Then we need to fix the compiler so that it outputs the continuous legend entries in the correct order.