### PR TITLE
add test coverage with coveralls

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -17,10 +17,13 @@ install:
   - $HOME/opt/pandoc/pandoc --version
   # install uninstalled packages which this pkg depends on/links to/suggests. 
   - ./travis-tool.sh install_deps
-  - ./travis-tool.sh install_github tdhock/ggplot2
+  - ./travis-tool.sh install_github tdhock/ggplot2  jimhester/covr
   
 script: 
   - Rscript -e "devtools::load_all(); setwd('tests'); source('testthat.R')"
+
+after_success:
+  - Rscript -e "library(covr);coveralls()"
 
 after_failure:
   - ./travis-tool.sh dump_logs

--- a/README.md
+++ b/README.md
@@ -2,6 +2,7 @@ animint - an R package for *anim*ated *int*eractive web graphics
 =======
 
 [![Build Status](https://travis-ci.org/tdhock/animint.png?branch=master)](https://travis-ci.org/tdhock/animint)
+[![Coverage Status](https://coveralls.io/repos/tdhock/animint/badge.svg?branch=master)](https://coveralls.io/r/tdhock/animint?branch=master)
 [![wercker status](https://app.wercker.com/status/3e56e443fb24a5ce304b706425ba6987/s/master "wercker status")](https://app.wercker.com/project/bykey/3e56e443fb24a5ce304b706425ba6987)
 
 Interactive animations using [ggplot2](https://github.com/hadley/ggplot2)'s grammar of graphics implementation combined with clickSelects and showSelected aesthetics.


### PR DESCRIPTION
This `covr` branch adds test coverage for animint. I have turned on coveralls for animint and the Travis build is passed. After `covr` merged, there will be a coverage status badge in README.md. The current test coverage is `77%`.