### PR TITLE
Fix bug where theme$legend.direction accidentally becomes NULL

### DIFF
--- a/R/animint.R
+++ b/R/animint.R
@@ -1096,9 +1096,10 @@ getLegendList <- function(plistextra){
   theme$legend.key.width <- if(is.null(theme$legend.key.width)) theme$legend.key.size
   theme$legend.key.height <- if(is.null(theme$legend.key.height)) theme$legend.key.size
   # by default, direction of each guide depends on the position of the guide.
-  theme$legend.direction <- if(is.null(theme$legend.direction)){
-    if (length(position) == 1 && position %in% c("top", "bottom", "left", "right"))
-      switch(position[1], top =, bottom = "horizontal", left =, right = "vertical")
+  if(is.null(theme$legend.direction)){
+    theme$legend.direction <- 
+      if (length(position) == 1 && position %in% c("top", "bottom", "left", "right"))
+        switch(position[1], top =, bottom = "horizontal", left =, right = "vertical")
     else
       "vertical"
   }

--- a/R/animint.R
+++ b/R/animint.R
@@ -1090,11 +1090,11 @@ getLegendList <- function(plistextra){
   theme <- ggplot2:::plot_theme(plot)
   position <- theme$legend.position
   # by default, guide boxes are vertically aligned
-  theme$legend.box <- if(is.null(theme$legend.box)) "vertical" else theme$legend.box
+  if(is.null(theme$legend.box)) theme$legend.box <- "vertical" else theme$legend.box
 
   # size of key (also used for bar in colorbar guide)
-  theme$legend.key.width <- if(is.null(theme$legend.key.width)) theme$legend.key.size
-  theme$legend.key.height <- if(is.null(theme$legend.key.height)) theme$legend.key.size
+  if(is.null(theme$legend.key.width)) theme$legend.key.width <- theme$legend.key.size
+  if(is.null(theme$legend.key.height)) theme$legend.key.height <- theme$legend.key.size
   # by default, direction of each guide depends on the position of the guide.
   if(is.null(theme$legend.direction)){
     theme$legend.direction <- 


### PR DESCRIPTION
I think there's a bug with the way that `is.null()` is being used sometimes.  The following example is typical of some of the code in `animint.R`.  I think the goal is for `x` to stay as 3, but that's not what R is doing.

```
x <- 3
x <- if(is.null(x)) 6
x
NULL
```

I think that it might make more sense for the code to be written this way.  

```
x <- 3
if(is.null(x)) x <- 6
x
[1] 3
```

Doing this will also help with #89 