### PR TITLE
bugfix for plots with many (>40) facet rows or columns

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,7 +1,7 @@
 Package: animint
 Maintainer: Toby Dylan Hocking <tdhock5@gmail.com>
-Author: Toby Dylan Hocking, Susan VanderPlas, Carson Sievert
-Version: 2015.09.08
+Author: Toby Dylan Hocking, Susan VanderPlas, Carson Sievert, Kevin Ferris, Tony Tsai
+Version: 2015.09.16
 License: GPL-3
 Title: Interactive animations
 Description: An interactive animation can be defined using a list of

--- a/NEWS
+++ b/NEWS
@@ -176,6 +176,15 @@ https://github.com/mbostock/d3/wiki/SVG-Shapes#symbol_type
 
 RENDER: Determine why border of tiles in pirates example does not seem to be rendering.
 
+2015.09.16
+
+BUGFIX: data renders properly when there are many facet rows or
+columns (before, there was some problem with scales that was causing
+negative data values).
+
+RENDER: theme(panel.margin=grid::unit(0, "lines")) is interpreted to
+mean no space between facets. Useful to save space with theme_bw().
+
 2015.09.08
 
 RENDER: For each selector variable, render a widget for selecting

--- a/R/animint.R
+++ b/R/animint.R
@@ -54,6 +54,10 @@ parsePlot <- function(meta){
   ## grid 0-1 scale). This allows transformations to be used
   ## out of the box, with no additional d3 coding.
   theme.pars <- ggplot2:::plot_theme(meta$plot)
+
+  ## Interpret panel.margin as the number of lines between facets
+  ## (ignoring whatever grid::unit such as cm that was specified).
+  plot.meta$panel_margin_lines <- as.numeric(theme.pars$panel.margin)
   
   ## No legend if theme(legend.postion="none").
   plot.meta$legend <- if(theme.pars$legend.position != "none"){

--- a/inst/examples/WorldBank-facets.R
+++ b/inst/examples/WorldBank-facets.R
@@ -18,49 +18,51 @@ min.years <- do.call(rbind, lapply(by.country, subset, year == min(year)))
 min.years$year <- 1958
 wb.facets <-
   list(ts=ggplot()+
-       xlab("")+
-       ylab("")+
-       geom_tallrect(aes(xmin=year-1/2, xmax=year+1/2,
-                         clickSelects=year),
-                     data=TS(years), alpha=1/2)+
-       theme_animint(width=1000, height=800)+
-       geom_line(aes(year, life.expectancy, group=country, colour=region,
-                     clickSelects=country),
-                 data=TS(not.na), size=4, alpha=3/5)+
-       geom_point(aes(year, life.expectancy, color=region, size=population,
-                      showSelected=country, clickSelects=country),
-                  data=TS(not.na))+
-       geom_text(aes(year, life.expectancy, colour=region, label=country,
-                     showSelected=country,
-                     clickSelects=country),
-                  data=TS(min.years), hjust=1)+
+         theme_bw()+
+         theme(panel.margin=grid::unit(0, "lines"))+
+         xlab("")+
+         ylab("")+
+         geom_tallrect(aes(xmin=year-1/2, xmax=year+1/2,
+                           clickSelects=year),
+                       data=TS(years), alpha=1/2)+
+         theme_animint(width=1000, height=800)+
+         geom_line(aes(year, life.expectancy, group=country, colour=region,
+                       clickSelects=country),
+                   data=TS(not.na), size=4, alpha=3/5)+
+         geom_point(aes(year, life.expectancy, color=region, size=population,
+                        showSelected=country, clickSelects=country),
+                    data=TS(not.na))+
+         geom_text(aes(year, life.expectancy, colour=region, label=country,
+                       showSelected=country,
+                       clickSelects=country),
+                   data=TS(min.years), hjust=1)+
 
-       geom_widerect(aes(ymin=year-1/2, ymax=year+1/2,
-                         clickSelects=year),
-                     data=TS2(years), alpha=1/2)+
-       geom_line(aes(fertility.rate, year, group=country, colour=region,
-                     clickSelects=country),
-                 data=TS2(not.na), size=4, alpha=3/5)+
-       geom_point(aes(fertility.rate, year, color=region, size=population,
-                      showSelected=country, clickSelects=country),
-                  data=TS2(not.na))+
+         geom_widerect(aes(ymin=year-1/2, ymax=year+1/2,
+                           clickSelects=year),
+                       data=TS2(years), alpha=1/2)+
+         geom_line(aes(fertility.rate, year, group=country, colour=region,
+                       clickSelects=country),
+                   data=TS2(not.na), size=4, alpha=3/5)+
+         geom_point(aes(fertility.rate, year, color=region, size=population,
+                        showSelected=country, clickSelects=country),
+                    data=TS2(not.na))+
 
-       geom_point(aes(fertility.rate, life.expectancy, clickSelects=country,
-                      showSelected=year, colour=region, size=population,
-                      key=country), # key aesthetic for animated transitions!
+         geom_point(aes(fertility.rate, life.expectancy, clickSelects=country,
+                        showSelected=year, colour=region, size=population,
+                        key=country), # key aesthetic for animated transitions!
 
-                  data=SCATTER(not.na))+
-       geom_text(aes(fertility.rate, life.expectancy, label=country,
-                     showSelected=country, showSelected2=year,
-                     showSelected3=region,
-                     clickSelects=country,
-                     key=country), #also use key here!
-                 data=SCATTER(not.na))+
-       scale_size_animint(breaks=10^(5:9))+
-       facet_grid(side ~ top, scales="free")+
-       geom_text(aes(5, 85, label=paste0("year = ", year),
-                     showSelected=year),
-                 data=SCATTER(years)),
+                    data=SCATTER(not.na))+
+         geom_text(aes(fertility.rate, life.expectancy, label=country,
+                       showSelected=country, showSelected2=year,
+                       showSelected3=region,
+                       clickSelects=country,
+                       key=country), #also use key here!
+                   data=SCATTER(not.na))+
+         scale_size_animint(breaks=10^(5:9))+
+         facet_grid(side ~ top, scales="free")+
+         geom_text(aes(5, 85, label=paste0("year = ", year),
+                       showSelected=year),
+                   data=SCATTER(years)),
        
        time=list(variable="year",ms=3000),
        

--- a/inst/htmljs/animint.js
+++ b/inst/htmljs/animint.js
@@ -164,14 +164,14 @@ var animint = function (to_select, json_file) {
     var npanels = Math.max.apply(null, panel_names);
 
     // Note axis names are "shared" across panels (just like the title)
-    var text_height_pixels = measureText(p_info["xtitle"], 11).height;
-    var xtitlepadding = 5 + text_height_pixels;
+    var xtitlepadding = 5 + measureText(p_info["xtitle"], 11).height;
     var ytitlepadding = 5 + measureText(p_info["ytitle"], 11).height;
 
     // 'margins' are fixed across panels and do not
     // include title/axis/label padding (since these are not
     // fixed across panels). They do, however, account for
     // spacing between panels
+    var text_height_pixels = measureText("foo", 11).height;
     var margin = {
       left: 0,
       right: text_height_pixels * p_info.panel_margin_lines,

--- a/inst/htmljs/animint.js
+++ b/inst/htmljs/animint.js
@@ -242,7 +242,7 @@ var animint = function (to_select, json_file) {
       return measureText(entry, 11).height;
     });
     var strip_widths = p_info.strips.right.map(function(entry){ 
-      return measureText(entry, 11).width; 
+      return measureText(entry, 11).height; 
     });
     // Be conservative and use the max width/height for determining graph region
     var strip_height = Math.max.apply(null, strip_heights);

--- a/inst/htmljs/animint.js
+++ b/inst/htmljs/animint.js
@@ -119,42 +119,6 @@ var animint = function (to_select, json_file) {
   var styles = [".axis path{fill: none;stroke: black;shape-rendering: crispEdges;}",
             ".axis line{fill: none;stroke: black;shape-rendering: crispEdges;}",
             ".axis text {font-family: sans-serif;font-size: 11px;}"];
-            
-  // 'margins' are fixed across panels and do not
-  // include title/axis/label padding (since these are not
-  // fixed across panels). They do, however, account for
-  // spacing between panels
-  var margin = {
-    left: 0,
-    right: 10,
-    top: 10,
-    bottom: 0
-  };
-  var plotdim = {
-    width: 0,
-    height: 0,
-    xstart: 0,
-    xend: 0,
-    ystart: 0,
-    yend: 0,
-    graph: {
-      width: 0,
-      height: 0
-    },
-    margin: margin,
-    xlab: {
-      x: 0,
-      y: 0
-    },
-    ylab: {
-      x: 0,
-      y: 0
-    },
-    title: {
-      x: 0,
-      y: 0
-    }
-  };
 
   var add_geom = function (g_name, g_info) {
     // Determine what style to use to show the selection for this
@@ -199,6 +163,47 @@ var animint = function (to_select, json_file) {
     var panel_names = p_info.layout.PANEL;
     var npanels = Math.max.apply(null, panel_names);
 
+    // Note axis names are "shared" across panels (just like the title)
+    var text_height_pixels = measureText(p_info["xtitle"], 11).height;
+    var xtitlepadding = 5 + text_height_pixels;
+    var ytitlepadding = 5 + measureText(p_info["ytitle"], 11).height;
+
+    // 'margins' are fixed across panels and do not
+    // include title/axis/label padding (since these are not
+    // fixed across panels). They do, however, account for
+    // spacing between panels
+    var margin = {
+      left: 0,
+      right: text_height_pixels * p_info.panel_margin_lines,
+      top: text_height_pixels * p_info.panel_margin_lines,
+      bottom: 0
+    };
+    var plotdim = {
+      width: 0,
+      height: 0,
+      xstart: 0,
+      xend: 0,
+      ystart: 0,
+      yend: 0,
+      graph: {
+	width: 0,
+	height: 0
+      },
+      margin: margin,
+      xlab: {
+	x: 0,
+	y: 0
+      },
+      ylab: {
+	x: 0,
+	y: 0
+      },
+      title: {
+	x: 0,
+	y: 0
+      }
+    };
+
     // Draw the title
     var titlepadding = measureText(p_info.title, 20).height + 10;
     // why are we giving the title padding if it is undefined?
@@ -211,13 +216,9 @@ var animint = function (to_select, json_file) {
       .attr("class", "title")
       .attr("font-family", "sans-serif")
       .attr("font-size", "20px")
-      .attr("transform", "translate(" + (plotdim.title.x) + "," + (
-        plotdim.title.y) + ")")
+      .attr("transform", "translate(" + plotdim.title.x + "," + 
+        plotdim.title.y + ")")
       .style("text-anchor", "middle");
-
-    // Note axis names are "shared" across panels (just like the title)
-    var xtitlepadding = 5 + measureText(p_info["xtitle"], 11).height;
-    var ytitlepadding = 5 + measureText(p_info["ytitle"], 11).height;
 
     // grab max text size over axis labels and facet strip labels
     var axispaddingy = 5;
@@ -233,12 +234,12 @@ var animint = function (to_select, json_file) {
 	     return measureText(entry, 11, p_info.xangle).height;
       }));
       // TODO: carefully calculating this gets complicated with rotating xlabs
-      margin.right += 5;
+      //margin.right += 5;
     }
     plotdim.margin = margin;
     
     var strip_heights = p_info.strips.top.map(function(entry){ 
-      return measureText(entry, 11).height; 
+      return measureText(entry, 11).height;
     })
     var strip_widths = p_info.strips.right.map(function(entry){ 
       return measureText(entry, 11).height; 
@@ -428,10 +429,10 @@ var animint = function (to_select, json_file) {
         }
         // assume right is top until it isn't
         var x = (plotdim.xstart + plotdim.xend) / 2;
-        var y = plotdim.ystart - strip_heights[layout_i] / 2;
+        var y = plotdim.ystart - strip_heights[layout_i] / 2 + 3;
         var rotate = 0;
         if (side == "right") {
-          x = plotdim.xend + strip_widths[layout_i] / 2;
+          x = plotdim.xend + strip_widths[layout_i] / 2 - 2;
           y = (plotdim.ystart + plotdim.yend) / 2;
           rotate = 90;
         }

--- a/inst/htmljs/animint.js
+++ b/inst/htmljs/animint.js
@@ -393,11 +393,11 @@ var animint = function (to_select, json_file) {
     // room for right strips should be distributed evenly across panels to preserve aspect ratio
     plotdim.xend = plotdim.xstart + plotdim.graph.width;
     // total height of strips drawn thus far
-    var strip_height = strip_heights.slice(0, current_row)
-                       .reduce(function(a, b) { return a + b; })
+    var strip_h = strip_heights.slice(0, current_row)
+        .reduce(function(a, b) { return a + b; })
     plotdim.ystart = current_row * plotdim.margin.top +
-                     (current_row - 1) * plotdim.margin.bottom +
-                     graph_height_cum + titlepadding + strip_height;
+        (current_row - 1) * plotdim.margin.bottom +
+        graph_height_cum + titlepadding + strip_h;
     // room for xaxis title should be distributed evenly across panels to preserve aspect ratio
     plotdim.yend = plotdim.ystart + plotdim.graph.height;
     // always add to the width (note it may have been reset earlier)

--- a/inst/htmljs/animint.js
+++ b/inst/htmljs/animint.js
@@ -304,16 +304,14 @@ var animint = function (to_select, json_file) {
       SVGs[g_name] = svg;
     });
 
-    // If we are to draw more than one panel,
-    // create a grouping for strip labels
-    if (npanels > 1) {
-      var topStrip = svg.append("g")
-        .attr("class", "strip")
-        .attr("id", "topStrip");
-      var rightStrip = svg.append("g")
-        .attr("class", "strip")
-        .attr("id", "rightStrip");
-    }
+    // create a grouping for strip labels (even if there are none).
+    var topStrip = svg.append("g")
+      .attr("class", "strip")
+      .attr("id", "topStrip");
+    var rightStrip = svg.append("g")
+      .attr("class", "strip")
+      .attr("id", "rightStrip");
+
     // this will hold x/y scales for each panel
     // eventually we inject this into Plots[p_name]
     var scales = {};

--- a/inst/htmljs/animint.js
+++ b/inst/htmljs/animint.js
@@ -255,10 +255,10 @@ var animint = function (to_select, json_file) {
 
     // the *entire graph* height/width
     var graph_width = p_info.options.width - ncols * (margin.left + margin.right) -
-                      strip_widths.reduce(function(a, b) { return a + b; }) -
+                      strip_widths[0] -
                       n_yaxes * axispaddingy - ytitlepadding;
     var graph_height = p_info.options.height - nrows * (margin.top + margin.bottom) -
-                        strip_heights.reduce(function(a, b) { return a + b; }) -
+                        strip_heights[0] -
                         titlepadding - n_xaxes * axispaddingx - xtitlepadding;
 
     // Impose the pixelated aspect ratio of the graph upon the width/height

--- a/inst/htmljs/animint.js
+++ b/inst/htmljs/animint.js
@@ -307,10 +307,10 @@ var animint = function (to_select, json_file) {
     // If we are to draw more than one panel,
     // create a grouping for strip labels
     if (npanels > 1) {
-      svg.append("g")
+      var topStrip = svg.append("g")
         .attr("class", "strip")
         .attr("id", "topStrip");
-      svg.append("g")
+      var rightStrip = svg.append("g")
         .attr("class", "strip")
         .attr("id", "rightStrip");
     }
@@ -364,94 +364,99 @@ var animint = function (to_select, json_file) {
         }
       }
 
-    axislabs(axis.x, axis.xlab, "x");
-    axislabs(axis.y, axis.ylab, "y");
+      axislabs(axis.x, axis.xlab, "x");
+      axislabs(axis.y, axis.ylab, "y");
 
-    // compute the current panel height/width
-    plotdim.graph.height = graph_height * hp[layout_i];
-    plotdim.graph.width = graph_width * wp[layout_i];
+      // compute the current panel height/width
+      plotdim.graph.height = graph_height * hp[layout_i];
+      plotdim.graph.width = graph_width * wp[layout_i];
 
-    var current_row = p_info.layout.ROW[layout_i];
-    var current_col = p_info.layout.COL[layout_i];
-    var draw_x = p_info.layout.AXIS_X[layout_i];
-    var draw_y = p_info.layout.AXIS_Y[layout_i];
-    // panels are drawn using a "typewriter approach" (left to right & top to bottom)
-    // if the carriage is returned (ie, there is a new row), change some parameters:
-    var new_row = current_col <= p_info.layout.COL[layout_i - 1]
-    if (new_row) {
-      n_yaxes = 0;
-      graph_width_cum = (graph_width_blank / 2) * graph_width;
-      graph_height_cum = graph_height_cum + plotdim.graph.height;
-    }
-    n_xaxes = n_xaxes + draw_x;
-    n_yaxes = n_yaxes + draw_y;
+      var current_row = p_info.layout.ROW[layout_i];
+      var current_col = p_info.layout.COL[layout_i];
+      var draw_x = p_info.layout.AXIS_X[layout_i];
+      var draw_y = p_info.layout.AXIS_Y[layout_i];
+      // panels are drawn using a "typewriter approach" (left to right & top to bottom)
+      // if the carriage is returned (ie, there is a new row), change some parameters:
+      var new_row = current_col <= p_info.layout.COL[layout_i - 1]
+      if (new_row) {
+	n_yaxes = 0;
+	graph_width_cum = (graph_width_blank / 2) * graph_width;
+	graph_height_cum = graph_height_cum + plotdim.graph.height;
+      }
+      n_xaxes = n_xaxes + draw_x;
+      n_yaxes = n_yaxes + draw_y;
 
-    // calculate panel specific locations to be used in placing axes, labels, etc.
-    plotdim.xstart =  current_col * plotdim.margin.left +
-                      (current_col - 1) * plotdim.margin.right +
-                      graph_width_cum + n_yaxes * axispaddingy + ytitlepadding;
-    // room for right strips should be distributed evenly across panels to preserve aspect ratio
-    plotdim.xend = plotdim.xstart + plotdim.graph.width;
-    // total height of strips drawn thus far
-    var strip_h = strip_heights.slice(0, current_row)
+      // calculate panel specific locations to be used in placing axes, labels, etc.
+      plotdim.xstart =  current_col * plotdim.margin.left +
+        (current_col - 1) * plotdim.margin.right +
+        graph_width_cum + n_yaxes * axispaddingy + ytitlepadding;
+      // room for right strips should be distributed evenly across panels to preserve aspect ratio
+      plotdim.xend = plotdim.xstart + plotdim.graph.width;
+      // total height of strips drawn thus far
+      var strip_h = strip_heights.slice(0, current_row)
         .reduce(function(a, b) { return a + b; })
-    plotdim.ystart = current_row * plotdim.margin.top +
+      plotdim.ystart = current_row * plotdim.margin.top +
         (current_row - 1) * plotdim.margin.bottom +
         graph_height_cum + titlepadding + strip_h;
-    // room for xaxis title should be distributed evenly across panels to preserve aspect ratio
-    plotdim.yend = plotdim.ystart + plotdim.graph.height;
-    // always add to the width (note it may have been reset earlier)
-    graph_width_cum = graph_width_cum + plotdim.graph.width;
+      // room for xaxis title should be distributed evenly across panels to preserve aspect ratio
+      plotdim.yend = plotdim.ystart + plotdim.graph.height;
+      // always add to the width (note it may have been reset earlier)
+      graph_width_cum = graph_width_cum + plotdim.graph.width;
 
-    // draw the y-axis title (and add padding) when drawing the first panel
-    if (layout_i === 0) {
-      svg.append("text")
-        .text(p_info["ytitle"])
-        .attr("class", "label")
-        .attr("id", "ytitle")
-        .style("text-anchor", "middle")
-        .style("font-size", "11px")
-        .attr("transform", "translate(" + (plotdim.xstart - axispaddingy - ytitlepadding / 2)
-          + "," + (p_info.options.height / 2) + ")rotate(270)");
-    }
-    // draw the x-axis title when drawing the last panel
-    if (layout_i === (npanels - 1)) {
-      svg.append("text")
-        .text(p_info["xtitle"])
-        .attr("class", "label")
-        .attr("id", "xtitle")
-        .style("text-anchor", "middle")
-        .style("font-size", "11px")
-        .attr("transform", "translate(" + plotdim.title.x
-          + "," + (plotdim.yend + axispaddingx) + ")");
-    }
+      // draw the y-axis title (and add padding) when drawing the first panel
+      if (layout_i === 0) {
+	svg.append("text")
+          .text(p_info["ytitle"])
+          .attr("class", "label")
+          .attr("id", "ytitle")
+          .style("text-anchor", "middle")
+          .style("font-size", "11px")
+          .attr("transform", "translate(" + (plotdim.xstart - axispaddingy - ytitlepadding / 2)
+		+ "," + (p_info.options.height / 2) + ")rotate(270)");
+      }
+      // draw the x-axis title when drawing the last panel
+      if (layout_i === (npanels - 1)) {
+	svg.append("text")
+          .text(p_info["xtitle"])
+          .attr("class", "label")
+          .attr("id", "xtitle")
+          .style("text-anchor", "middle")
+          .style("font-size", "11px")
+          .attr("transform", "translate(" + plotdim.title.x
+		+ "," + (plotdim.yend + axispaddingx) + ")");
+      }
 
       var draw_strip = function(strip, side) {
         if (strip == "") {
           return(null);
         }
-        // assume right is top until it isn't
-        var x = (plotdim.xstart + plotdim.xend) / 2;
-        var y = plotdim.ystart - strip_heights[layout_i] / 2 + 3;
-        var rotate = 0;
+        var x, y, rotate, stripElement;
         if (side == "right") {
           x = plotdim.xend + strip_widths[layout_i] / 2 - 2;
           y = (plotdim.ystart + plotdim.yend) / 2;
           rotate = 90;
-        }
-        //create a group
-        svg.select("#" + side + "Strip")
+	  stripElement = rightStrip;
+        }else{ //top
+	  x = (plotdim.xstart + plotdim.xend) / 2;
+          y = plotdim.ystart - strip_heights[layout_i] / 2 + 3;
+	  rotate = 0;
+	  stripElement = topStrip;
+	}
+	var trans_text = "translate(" + x + "," + y + ")";
+	var rot_text = "rotate(" + rotate + ")";
+	stripElement
           .selectAll("." + side + "Strips")
           .data(strip)
           .enter()
-            .append("text")
-            .style("text-anchor", "middle")
-            .style("font-size", "11px")
-            .text(function(d) { return d; })
-            // NOTE: there could be multiple strips per panel
-            // TODO: is there a better way to manage spacing?
-            .attr("transform", "translate(" + x + "," + y + ")rotate(" + rotate + ")");
-        }
+          .append("text")
+          .style("text-anchor", "middle")
+          .style("font-size", "11px")
+          .text(function(d) { return d; })
+        // NOTE: there could be multiple strips per panel
+        // TODO: is there a better way to manage spacing?
+          .attr("transform", trans_text + rot_text)
+	;
+      }
       draw_strip([p_info.strips.top[layout_i]], "top");
       draw_strip([p_info.strips.right[layout_i]], "right");
 
@@ -490,38 +495,38 @@ var animint = function (to_select, json_file) {
 	  .attr("transform", "rotate(" + p_info.xangle + " 0 9)");
       }
       if(draw_y){
-	     var yaxis = d3.svg.axis()
+	var yaxis = d3.svg.axis()
           .scale(scales[panel_i].y)
           .tickValues(yaxisvals)
           .tickFormat(function (d) {
             return yaxislabs[yaxisvals.indexOf(d)].toString();
           })
           .orient("left");
-	     svg.append("g")
+	svg.append("g")
           .attr("class", "axis")
           .attr("id", "yaxis")
           .attr("transform", "translate(" + (plotdim.xstart) + ",0)")
           .call(yaxis);
       }
 
-    	if(!axis.xline) {
-    	  styles.push("#"+p_name+" #xaxis"+" path{stroke:none;}");
-    	}
-    	if(!axis.xticks) {
-    	  styles.push("#"+p_name+" #xaxis .tick"+" line{stroke:none;}");
-    	}
-    	if(!axis.yline) {
-    	  styles.push("#"+p_name+" #yaxis"+" path{stroke:none;}");
-    	}
-    	if(!axis.yticks) {
-    	  styles.push("#"+p_name+" #yaxis .tick"+" line{stroke:none;}");
-    	}
+      if(!axis.xline) {
+    	styles.push("#"+p_name+" #xaxis"+" path{stroke:none;}");
+      }
+      if(!axis.xticks) {
+    	styles.push("#"+p_name+" #xaxis .tick"+" line{stroke:none;}");
+      }
+      if(!axis.yline) {
+    	styles.push("#"+p_name+" #yaxis"+" path{stroke:none;}");
+      }
+      if(!axis.yticks) {
+    	styles.push("#"+p_name+" #yaxis .tick"+" line{stroke:none;}");
+      }
       
       // creating g element for background, grid lines, and border
       // uses insert to draw it right before plot title
       var background = svg.insert("g", "#plottitle")
         .attr("class", "background");
-        
+      
       // drawing background
       if(Object.keys(p_info.panel_background).length > 1) {
         background.append("rect")
@@ -546,9 +551,9 @@ var animint = function (to_select, json_file) {
           var lt = grid_background.linetype;
           var size = grid_background.size;
           var cap = grid_background.lineend;
-        // group for grid lines
-        var grid = background.append("g")
-          .attr("class", grid_class);
+          // group for grid lines
+          var grid = background.append("g")
+            .attr("class", grid_class);
 
           // group for horizontal grid lines
           var grid_hor = grid.append("g")
@@ -620,7 +625,7 @@ var animint = function (to_select, json_file) {
           });
       }
 
-    } //end of for loop
+    } //end of for(layout_i
 
     Plots[p_name].scales = scales;
 

--- a/tests/testthat/test-many-facets.R
+++ b/tests/testthat/test-many-facets.R
@@ -60,7 +60,7 @@ translatePattern <-
 
 test_that("right strips all at the same x position", {
   text.list <-
-    getNodeSet(info$html, '//svg[@id="vertical"]//g[@id="rightStrip"]//text')
+    getNodeSet(info$html, '//svg[@id="vertical"]//g[@class="strip"]//text')
   expect_equal(length(text.list), n.circles)
   translate.vec <- sapply(text.list, function(x)xmlAttrs(x)[["transform"]])
   translate.mat <- str_match_perl(translate.vec, translatePattern)

--- a/tests/testthat/test-many-facets.R
+++ b/tests/testthat/test-many-facets.R
@@ -1,0 +1,28 @@
+library(animint)
+library(testthat)
+
+context("many facets")
+
+n.circles <- 40
+df <- data.frame(x=0, y=0, facet=1:n.circles)
+viz <-
+  list(horizontal=ggplot()+
+         theme_animint(width=n.circles * 30 + 50)+
+         geom_point(aes(x, y), data=df)+
+         facet_grid(. ~ facet),
+       vertical=ggplot()+
+         theme_animint(height=n.circles * 30 + 50)+
+         geom_point(aes(x, y), data=df)+
+         facet_grid(facet ~ .))
+info <- animint2HTML(viz)
+
+test_that("points have positive positions", {
+  circle.list <-
+    getNodeSet(info$html, '//circle')
+  expect_equal(length(circle.list), n.circles * 2)
+  xy.vec <- as.numeric(sapply(circle.list, function(circle){
+    xmlAttrs(circle)[c("cx", "cy")]
+  }))
+  expect_true(all(0 < xy.vec))
+})
+

--- a/tests/testthat/test-many-facets.R
+++ b/tests/testthat/test-many-facets.R
@@ -50,3 +50,20 @@ test_that("no vertical space between border_rects", {
   second.top <- as.numeric(second[["y"]])
   expect_equal(first.bottom, second.top)
 })
+
+translatePattern <-
+  paste0("translate[(]",
+         "(?<x>.*?)",
+         ",",
+         "(?<y>.*?)",
+         "[)]")
+
+test_that("right strips all at the same x position", {
+  text.list <-
+    getNodeSet(info$html, '//g[@id="rightStrip"]//text')
+  expect_equal(length(text.list), n.circles)
+  translate.vec <- sapply(text.list, function(x)xmlAttrs(x)[["transform"]])
+  translate.mat <- str_match_perl(translate.vec, translatePattern)
+  x.vec <- as.numeric(translate.mat[, "x"])
+  expect_true(all(x.vec[[1]] == x.vec))
+})

--- a/tests/testthat/test-many-facets.R
+++ b/tests/testthat/test-many-facets.R
@@ -16,6 +16,7 @@ viz <-
        vertical=gg+
          theme_animint(height=n.circles * 30 + 50)+
          facet_grid(facet ~ .))
+
 info <- animint2HTML(viz)
 
 test_that("points have positive positions", {

--- a/tests/testthat/test-many-facets.R
+++ b/tests/testthat/test-many-facets.R
@@ -60,7 +60,7 @@ translatePattern <-
 
 test_that("right strips all at the same x position", {
   text.list <-
-    getNodeSet(info$html, '//g[@id="rightStrip"]//text')
+    getNodeSet(info$html, '//svg[@id="vertical"]//g[@id="rightStrip"]//text')
   expect_equal(length(text.list), n.circles)
   translate.vec <- sapply(text.list, function(x)xmlAttrs(x)[["transform"]])
   translate.mat <- str_match_perl(translate.vec, translatePattern)

--- a/tests/testthat/test-many-facets.R
+++ b/tests/testthat/test-many-facets.R
@@ -5,14 +5,16 @@ context("many facets")
 
 n.circles <- 40
 df <- data.frame(x=0, y=0, facet=1:n.circles)
+gg <- ggplot()+
+  geom_point(aes(x, y), data=df)+
+  theme_bw()+
+  theme(panel.margin=grid::unit(0, "cm"))
 viz <-
-  list(horizontal=ggplot()+
+  list(horizontal=gg+
          theme_animint(width=n.circles * 30 + 50)+
-         geom_point(aes(x, y), data=df)+
          facet_grid(. ~ facet),
-       vertical=ggplot()+
+       vertical=gg+
          theme_animint(height=n.circles * 30 + 50)+
-         geom_point(aes(x, y), data=df)+
          facet_grid(facet ~ .))
 info <- animint2HTML(viz)
 
@@ -26,3 +28,24 @@ test_that("points have positive positions", {
   expect_true(all(0 < xy.vec))
 })
 
+test_that("no horizontal space between border_rects", {
+  rect.list <-
+    getNodeSet(info$html, '//svg[@id="horizontal"]//rect[@class="border_rect"]')
+  expect_equal(length(rect.list), n.circles)
+  first <- xmlAttrs(rect.list[[1]])
+  first.right <- as.numeric(first[["x"]])+as.numeric(first[["width"]])
+  second <- xmlAttrs(rect.list[[2]])
+  second.left <- as.numeric(second[["x"]])
+  expect_equal(first.right, second.left)
+})
+
+test_that("no vertical space between border_rects", {
+  rect.list <-
+    getNodeSet(info$html, '//svg[@id="vertical"]//rect[@class="border_rect"]')
+  expect_equal(length(rect.list), n.circles)
+  first <- xmlAttrs(rect.list[[1]])
+  first.bottom <- as.numeric(first[["y"]])+as.numeric(first[["height"]])
+  second <- xmlAttrs(rect.list[[2]])
+  second.top <- as.numeric(second[["y"]])
+  expect_equal(first.bottom, second.top)
+})

--- a/tests/testthat/test-many-facets.R
+++ b/tests/testthat/test-many-facets.R
@@ -65,5 +65,9 @@ test_that("right strips all at the same x position", {
   translate.vec <- sapply(text.list, function(x)xmlAttrs(x)[["transform"]])
   translate.mat <- str_match_perl(translate.vec, translatePattern)
   x.vec <- as.numeric(translate.mat[, "x"])
-  expect_true(all(x.vec[[1]] == x.vec))
+  expected.val <- x.vec[[1]]
+  expected.vec <- rep(expected.val, length(x.vec))
+  print(rbind(computed=x.vec,
+              expected=expected.vec))
+  expect_equal(x.vec, expected.vec)
 })

--- a/tests/testthat/test-panels.R
+++ b/tests/testthat/test-panels.R
@@ -9,7 +9,7 @@ p1 <- ggplot() +
                                     color = "black",
                                     size = 2,
                                     linetype = "dashed"),
-        panel.margin = grid::unit(.1, "cm")) +
+        panel.margin = grid::unit(0.1, "cm")) +
   facet_wrap(~Species, nrow = 2)
 p2 <- ggplot() +
   geom_point(aes(Petal.Length, Petal.Width,
@@ -33,6 +33,19 @@ p4 <- p2 +
         complete = T)
 
 info <- animint2HTML(list(sepal = p1, petal = p2, blank = p3, gg538 = p4))
+
+rect.list <-
+  getNodeSet(info$html, '//svg[@id="sepal"]//rect[@class="border_rect"]')
+expect_equal(length(rect.list), 3)
+at.mat <- sapply(rect.list, xmlAttrs)
+
+test_that("four unique border_rect x values (some horiz space)", {
+  left.vec <- as.numeric(at.mat["x", ])
+  width.vec <- as.numeric(at.mat["width", ])
+  right.vec <- left.vec + width.vec
+  x.values <- unique(c(left.vec, right.vec))
+  expect_equal(length(x.values), 4)
+})
 
 # extracting html from plots --------------------------------------
 

--- a/tests/testthat/test-widerect.R
+++ b/tests/testthat/test-widerect.R
@@ -77,7 +77,7 @@ rect.list <-
 expect_equal(length(rect.list), 4)
 at.mat <- sapply(rect.list, xmlAttrs)
 
-test_that("no horizontal space between border_rects", {
+test_that("three unique border_rect x values (no horiz space)", {
   left.vec <- as.numeric(at.mat["x", ])
   width.vec <- as.numeric(at.mat["width", ])
   right.vec <- left.vec + width.vec
@@ -85,7 +85,7 @@ test_that("no horizontal space between border_rects", {
   expect_equal(length(x.values), 3)
 })
 
-test_that("no vertical space between border_rects", {
+test_that("three unique border_rect y values (no vert space)", {
   top.vec <- as.numeric(at.mat["y", ])
   height.vec <- as.numeric(at.mat["height", ])
   bottom.vec <- top.vec + height.vec

--- a/tests/testthat/test-widerect.R
+++ b/tests/testthat/test-widerect.R
@@ -20,6 +20,7 @@ wb.facets <-
                          clickSelects=year),
                      data=TS(years), alpha=1/2)+
        theme_animint(width=1000, height=800)+
+       theme(panel.margin=grid::unit(0, "lines"))+
        geom_line(aes(year, life.expectancy, group=country, colour=region,
                      clickSelects=country, id = country),
                  data=TS(not.na), size=4, alpha=3/5)+

--- a/tests/testthat/test-widerect.R
+++ b/tests/testthat/test-widerect.R
@@ -19,6 +19,7 @@ wb.facets <-
                          linetype=status,
                          clickSelects=year),
                      data=TS(years), alpha=1/2)+
+       theme_bw()+
        theme_animint(width=1000, height=800)+
        theme(panel.margin=grid::unit(0, "lines"))+
        geom_line(aes(year, life.expectancy, group=country, colour=region,

--- a/tests/testthat/test-widerect.R
+++ b/tests/testthat/test-widerect.R
@@ -70,6 +70,27 @@ wb.facets <-
 
 info <- animint2HTML(wb.facets)
 
+rect.list <-
+  getNodeSet(info$html, '//svg[@id="ts"]//rect[@class="border_rect"]')
+expect_equal(length(rect.list), 4)
+at.mat <- sapply(rect.list, xmlAttrs)
+
+test_that("no horizontal space between border_rects", {
+  left.vec <- as.numeric(at.mat["x", ])
+  width.vec <- as.numeric(at.mat["width", ])
+  right.vec <- left.vec + width.vec
+  x.values <- unique(c(left.vec, right.vec))
+  expect_equal(length(x.values), 3)
+})
+
+test_that("no vertical space between border_rects", {
+  top.vec <- as.numeric(at.mat["y", ])
+  height.vec <- as.numeric(at.mat["height", ])
+  bottom.vec <- top.vec + height.vec
+  y.values <- unique(c(top.vec, bottom.vec))
+  expect_equal(length(y.values), 3)
+})
+
 dasharrayPattern <-
   paste0("stroke-dasharray:",
          "(?<value>.*?)",


### PR DESCRIPTION
![screenshot-many-facets-bug](https://cloud.githubusercontent.com/assets/932850/9903703/7c8f2298-5c46-11e5-8104-b7fc96efdf28.png)

Scales behave improperly when there are many facets. For example when there are many (>40) rows, any x values get scaled to negative values, so only the axes and strips (but no data) are rendered.