### PR TITLE
hline test fails

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,7 +1,7 @@
 Package: animint
 Maintainer: Toby Dylan Hocking <tdhock5@gmail.com>
 Author: Toby Dylan Hocking, Susan VanderPlas, Carson Sievert, Kevin Ferris, Tony Tsai
-Version: 2015.09.18
+Version: 2015.09.22
 License: GPL-3
 Title: Interactive animations
 Description: An interactive animation can be defined using a list of

--- a/NEWS
+++ b/NEWS
@@ -176,6 +176,11 @@ https://github.com/mbostock/d3/wiki/SVG-Shapes#symbol_type
 
 RENDER: Determine why border of tiles in pirates example does not seem to be rendering.
 
+2015.09.22
+
+BUGFIX: geom_hline is now rendered properly. Test includes with and
+without the data= argument.
+
 2015.09.18
 
 BUGFIX: geom_line was not rendering properly when the x values were

--- a/R/animint.R
+++ b/R/animint.R
@@ -774,7 +774,7 @@ saveLayer <- function(l, d, meta){
       write.table(some.lines, tmp,
                   col.names=FALSE,
                   quote=FALSE, row.names=FALSE, sep="\t")
-      bytes <- file.size(tmp)
+      bytes <- file.info(tmp)$size
       bytes.per.line <- bytes/nrow(some.lines)
       bad.chunk <- function(){
         if(all(!can.chunk))return(NULL)

--- a/inst/htmljs/animint.js
+++ b/inst/htmljs/animint.js
@@ -1332,8 +1332,8 @@ var animint = function (to_select, json_file) {
       eActions = function (e) {
         e.attr("y1", toXY("y", "yintercept"))
           .attr("y2", toXY("y", "yintercept"))
-          .attr("x1", scales.x.range()[0] + plotdim.margin.left)
-          .attr("x2", scales.x.range()[1] - plotdim.margin.right)
+          .attr("x1", scales.x.range()[0])
+          .attr("x2", scales.x.range()[1])
           .style("stroke-dasharray", get_dasharray)
           .style("stroke-width", get_size)
           .style("stroke", get_colour);

--- a/tests/testthat/test-hline.R
+++ b/tests/testthat/test-hline.R
@@ -1,0 +1,36 @@
+library(testthat)
+context("hline")
+
+n.rows <- 100
+df <- data.frame(x=rnorm(n.rows), y=rnorm(n.rows))
+sc <- ggplot()+
+  geom_point(aes(x, y), data=df)
+two <- data.frame(x=c(0, 1))
+
+viz <-
+  list(one=sc+
+         geom_hline(yintercept=0)+
+         geom_vline(xintercept=0),
+
+       two=sc+
+         geom_hline(aes(yintercept=x), data=two)+
+         geom_vline(aes(xintercept=x), data=two))
+
+info <- animint2HTML(viz)
+
+line.class.vec <-
+  c("geom2_hline_one"=1, "geom3_vline_one"=1,
+    "geom5_hline_two"=2, "geom6_vline_two"=2)
+
+test_that("hlines and vlines appear", {
+  for(line.class in names(line.class.vec)){
+    xpath <- sprintf('//g[@class="%s"]//line', line.class)
+    line.list <- getNodeSet(info$html, xpath)
+    expected.length <- line.class.vec[[line.class]]
+    expect_equal(length(line.list), expected.length)
+    attr.mat <- sapply(line.list, xmlAttrs)
+    xy.mat <- attr.mat[c("x1", "x2", "y1", "y2"), ]
+    xy.vec <- as.numeric(xy.mat)
+    expect_true(all(is.finite(xy.vec)))
+  }
+})


### PR DESCRIPTION
There is a bug in rendering hlines

![screenshot-bug-hline](https://cloud.githubusercontent.com/assets/932850/10021633/e44e6aea-6116-11e5-988d-2d6d79c77fff.png)

The x1 and x2 attributes are not added to the `<line>` elements.

I added a test.

Should be an easy fix.