### PR TITLE
test clickSelects.variable tooltip fails

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,7 +1,7 @@
 Package: animint
 Maintainer: Toby Dylan Hocking <tdhock5@gmail.com>
 Author: Toby Dylan Hocking, Susan VanderPlas, Carson Sievert, Kevin Ferris, Tony Tsai
-Version: 2015.09.22
+Version: 2015.09.23
 License: GPL-3
 Title: Interactive animations
 Description: An interactive animation can be defined using a list of

--- a/NEWS
+++ b/NEWS
@@ -176,6 +176,10 @@ https://github.com/mbostock/d3/wiki/SVG-Shapes#symbol_type
 
 RENDER: Determine why border of tiles in pirates example does not seem to be rendering.
 
+2015.09.23
+
+BUGFIX: tooltips render for geoms with clickSelects.variable/value.
+
 2015.09.22
 
 BUGFIX: geom_hline is now rendered properly. Test includes with and

--- a/inst/htmljs/animint.js
+++ b/inst/htmljs/animint.js
@@ -1627,16 +1627,18 @@ var animint = function (to_select, json_file) {
       elements.style("opacity", get_alpha);
     }
     var has_tooltip = g_info.aes.hasOwnProperty("tooltip");
-    if(has_clickSelects || has_tooltip){
+    if(has_clickSelects || has_tooltip || has_clickSelects_variable){
       elements.text("")
         .append("svg:title")
         .text(function (d) {
           if(has_tooltip){
             return d.tooltip;
-          }else{
+          }else if(has_clickSelects){
             var v_name = g_info.aes.clickSelects;
             return v_name + " " + d.clickSelects;
-          }
+          }else{ //clickSelects_variable
+	    return d["clickSelects.variable"] + " " + d["clickSelects.value"];
+	  }
         });
     }
     // Set attributes of only the entering elements. This is needed to

--- a/tests/testthat/test-variable-value.R
+++ b/tests/testthat/test-variable-value.R
@@ -153,7 +153,6 @@ test_that("clickSelects.variable tooltip/title", {
   expect_identical(title.vec, paste("size.100.problem.1peaks", 0:2))
 })
 
-
 test_that("two lines rendered in first plot", {
   path.list <-
     getNodeSet(info$html,

--- a/tests/testthat/test-variable-value.R
+++ b/tests/testthat/test-variable-value.R
@@ -142,6 +142,18 @@ viz <-
 
 info <- animint2HTML(viz)
 
+circle.xpath <- '//svg[@id="peaks"]//circle'
+title.xpath <- paste0(circle.xpath, '//title')
+
+test_that("clickSelects.variable tooltip/title", {
+  circle.list <- getNodeSet(info$html, circle.xpath)
+  expect_equal(length(circle.list), 3)
+  title.list <- getNodeSet(info$html, title.xpath)
+  title.vec <- sapply(title.list, xmlValue)
+  expect_identical(title.vec, paste("size.100.problem.1peaks", 0:2))
+})
+
+
 test_that("two lines rendered in first plot", {
   path.list <-
     getNodeSet(info$html,
@@ -192,8 +204,6 @@ test_that("clicking increases the number of peaks", {
   node.list <-
     getNodeSet(more.peaks.html, '//g[@class="geom6_segment_problems"]//line')
   expect_equal(length(node.list), 3)
-  ## TODO: test for //g[@class="geom6_point_peaks"]//circle//title
-  ## (tooltip that indicates the number of peaks).
 })
 
 viz.for <-
@@ -299,3 +309,10 @@ test_that("changing problem downloads one chunk", {
                  0, 0, 0, 0))
 })
 
+test_that("clickSelects tooltip/title", {
+  circle.list <- getNodeSet(info$html, circle.xpath)
+  expect_equal(length(circle.list), 3)
+  title.list <- getNodeSet(info$html, title.xpath)
+  title.vec <- sapply(title.list, xmlValue)
+  expect_identical(title.vec, paste("size.100.problem.1peaks", 0:2))
+})


### PR DESCRIPTION
It would be nice if the default tooltip showed the value that would be selected when you click on it.

It currently works for `aes(clickSelects)` but not for `aes(clickSelects.variable, clickSelects.value)`.